### PR TITLE
Fix orgrr adjust links

### DIFF
--- a/orgrr.el
+++ b/orgrr.el
@@ -68,6 +68,7 @@
   "Show all backlinks in `org-directory' to the current org-file."
 ;; TODO: add unlinked references below backlinks!
   (interactive)
+  (orgrr-get-all-filenames)
   (if (not (string-match-p "backlinks for *" (buffer-name (current-buffer))))
       (progn
 	(orgrr-get-meta)
@@ -358,6 +359,7 @@
   (orgrr-collect-project-snippet)
   (orgrr-format-project-snippet snippet)
   (orgrr-pick-project)
+  (orgrr-get-all-filenames)
   (setq titles (hash-table-keys orgrr-title-filename))
   (if (member selection titles)
     (progn
@@ -438,7 +440,6 @@ A use case could be to add snippets to a writing project, which is located in a 
 	 
 (defun orgrr-adjust-links (string)
   "Adjusts/corrects all links of STRING relative to the position of the note."
-  (orgrr-get-all-filenames)
   (setq path-of-current-note
       (if (buffer-file-name)
           (file-name-directory (buffer-file-name))

--- a/orgrr.el
+++ b/orgrr.el
@@ -313,6 +313,7 @@
 	      (setq org-directory new-container)
 	      (orgrr-open-file (concat new-container "/" (file-name-nondirectory filename))) 
 	      (orgrr-fix-all-links-buffer)
+	      (save-some-buffers t)
 	    (message "Note has been moved and links have been adjusted!"))
 	  (message "Note not moved!")))
     (message "Container does not exist."))

--- a/orgrr.el
+++ b/orgrr.el
@@ -289,6 +289,9 @@
 (defun orgrr-move-note ()
   "Move current note to one of the other containers."
   (interactive)
+  
+
+
   (setq orgrr-name-container (make-hash-table :test 'equal))
   (if (buffer-file-name)
       (setq filename (buffer-file-name)))
@@ -305,6 +308,7 @@
 	    (progn
 	    (rename-file filename (concat new-container "/" (file-name-nondirectory filename)))
 	    (message "Note has been moved!"))
+	  
 	  (message "Note not moved!")))
     (message "Container does not exist."))
   (clrhash orgrr-name-container))
@@ -625,8 +629,10 @@ A use case could be to add snippets to a writing project, which is located in a 
   (interactive)
   (orgrr-check-for-container-file)
   (ogrr-get-list-of-containers)
-  (let* ((containers (nreverse (hash-table-keys orgrr-name-container)))
-	 (selection (completing-read "" containers)))
+  (let* ((containers (nreverse (hash-table-keys orgrr-name-container))))
+    (if container
+	(setq selection container)
+      (setq selection (completing-read "" containers)))
     (if (member selection containers)
 	(setq org-directory (gethash selection orgrr-name-container))
       (message "Container does not exist.")))

--- a/orgrr.el
+++ b/orgrr.el
@@ -4,7 +4,7 @@
 
 ;; Maintainer: René Trappel <rtrappel@gmail.com>
 ;; URL:
-;; Version: 0.6.9
+;; Version: 0.7.0
 ;; Package-Requires: emacs "26", rg
 ;; Keywords: org-roam notes zettelkasten
 
@@ -33,8 +33,8 @@
 ;;
 ;;; News
 ;;
-;; 0.6.9
-;; - added orgrr-random-note
+;; 0.7.0
+;; - orgrr-add-to-project now works across containers
 ;;
 ;;; Code:
 

--- a/readme.md
+++ b/readme.md
@@ -186,7 +186,7 @@ This function deletes the current note and shows the previous buffer.
 
 ### orgrr-move-note
 
-This function allows to move the current note to one of the other containers. 
+This function allows to move the current note to one of the other containers. All links will be adjusted accordingly.
 
 ### orgrr-random-note
 

--- a/readme.md
+++ b/readme.md
@@ -132,9 +132,9 @@ On the most basic level, an orgrr-project is any note that has the tag `orgrr-pr
 #+roam_tags: orgrr-project
 ```
 
-The function [orgrr-add-to-project](#orgrr-add-to-project) takes the current paragraph visited at point (the cursor) in an org-file (in the org-directory or its sub-directories) or in orgrr-backlinks and appends it to a chosen project. A source-link is added, to allow for follow-up. If the project name does not yet exist, a new orgrr-project is created in the org-directory (similar to the way orgrr-find and orgrr-insert operate).
+The function [orgrr-add-to-project](#orgrr-add-to-project) takes the current paragraph visited at point (the cursor) in an org-file (in the org-directory or its sub-directories) or in orgrr-backlinks and appends it to a chosen project. A source-link is added, to allow for follow-up. If the project name does not yet exist, a new orgrr-project is created in the org-directory (similar to the way orgrr-find and orgrr-insert operate). This feature works across [orgrr-containers](#orgrr-containers). 
 
-Orgrr-projects thereby facilitate rapid access to a set of paragraphs and are the main holding area for work in progress in orgrr. 
+Orgrr-projects thereby facilitate rapid access to a set of paragraphs and are the main holding area for work in progress in orgrr. It also allows for writing projects in different containers than the location of the original note. 
 
 ### orgrr-related-notes
 


### PR DESCRIPTION
This provides substantial improvements when moving notes between containers. Now links and backlinks will be adjusted to take into account the new location.